### PR TITLE
Poseidon(0.0.5 pre1)'s TopicMetadata patitions method became private. us...

### DIFF
--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -89,6 +89,7 @@ class Poseidon::ConsumerGroup
   # @option options [Integer] :min_bytes Smallest amount of data the server should send us. Default: 0 (Send us data as soon as it is ready)
   # @option options [Integer] :claim_timeout Maximum number of seconds to wait for a partition claim. Default: 10
   # @option options [Integer] :loop_delay Number of seconds to delay the next fetch (in #fetch_loop) if nothing was returned. Default: 1
+  # @option options [Integer] :socket_timeout_ms broker connection wait timeout in ms. Default: 10000
   # @option options [Boolean] :register Automatically register instance and start consuming. Default: true
   # @option options [Boolean] :trail Starts reading messages from the latest partitions offsets and skips 'old' messages . Default: false
   #
@@ -97,9 +98,12 @@ class Poseidon::ConsumerGroup
     @name       = name
     @topic      = topic
     @zk         = ::ZK.new(zookeepers.join(","))
+    # Poseidon::BrokerPool doesn't provide default value for this option
+    # Configuring default value like this isn't beautiful, though.. by kssminus
+    options[:socket_timeout_ms] ||= 10000
     @options    = options
     @consumers  = []
-    @pool       = ::Poseidon::BrokerPool.new(id, brokers)
+    @pool       = ::Poseidon::BrokerPool.new(id, brokers, options[:socket_timeout_ms])
     @mutex      = Mutex.new
     @registered = false
 


### PR DESCRIPTION
Poseidon(0.0.5 pre1)'s TopicMetadata patitions method became private. 

need to use alternative method **available_partitions**

ps. Dependent Poseidon versions should be specified?
