### PR TITLE
Remove the :register option after check

### DIFF
--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -107,7 +107,7 @@ class Poseidon::ConsumerGroup
     @mutex      = Mutex.new
     @registered = false
 
-    register! unless options[:register] == false
+    register! unless options.delete(:register) == false
   end
 
   # @return [String] a globally unique identifier


### PR DESCRIPTION
Poseidon seems to be very fussy about the options that are passed
through to it.  The options hash here makes it into poseidon, which will
blow up if the :register option is provided (whatever value ...) ... so,
clean up after checking it.