### PR TITLE
handle deferred registration cleanly

### DIFF
--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -107,7 +107,7 @@ class Poseidon::ConsumerGroup
     @mutex      = Mutex.new
     @registered = false
 
-    register! unless options[:register] == false
+    register! unless options.delete(:register) == false
   end
 
   # @return [String] a globally unique identifier

--- a/spec/lib/poseidon/consumer_group_spec.rb
+++ b/spec/lib/poseidon/consumer_group_spec.rb
@@ -76,6 +76,16 @@ describe Poseidon::ConsumerGroup do
     subject
   end
 
+  it "should defer registration when asked to" do
+    client = described_class.new "my-group", ["localhost:29092", "localhost:29091"], ["localhost:22181"], "mytopic", register: false
+
+    client.should_not be_registered
+    zk_client.should_not have_received(:register)
+
+    client.register!
+    client.should be_registered
+  end
+
   it "should sort partitions by leader address" do
     subject.partitions.map(&:id).should == [1, 0]
   end


### PR DESCRIPTION
The spec reproduces a case where registration is deferred.

The registration option gets passed to the posideon partiton consumer,
which validates it's option set, resulting in an error:

   Failure/Error: client.register!
   ArgumentError:
     Unknown options: [:register]