### PR TITLE
Delete the option  :claim_timeout before  ::Poseidon::PartitionConsumer#initialize

### DIFF
--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -401,9 +401,12 @@ class Poseidon::ConsumerGroup
 
     # Claim the ownership of the partition for this consumer
     # @raise [Timeout::Error]
+    #
+    # Delete the option "claim_timeout" here, because ::Poseidon::PartitionConsumer#initialize
+    # doesn't accept the option "claim_timeout".
     def claim!(partition)
       path = claim_path(partition)
-      Timeout.timeout options[:claim_timeout] || options[:claim_timout] || DEFAULT_CLAIM_TIMEOUT do
+      Timeout.timeout options.delete(:claim_timeout) || DEFAULT_CLAIM_TIMEOUT do
         while zk.create(path, id, ephemeral: true, ignore: :node_exists).nil?
           return if @pending
           sleep(0.1)


### PR DESCRIPTION
 Delete the option "claim_timeout" in the method 'claim!',  because::Poseidon::PartitionConsumer#initialize doesn't accept the option "claim_timeout".
