### PR TITLE
Make partition picker fairer

### DIFF
--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -51,11 +51,25 @@ class Poseidon::ConsumerGroup
   def self.pick(pnum, cids, id)
     cids = cids.sort
     pos  = cids.index(id)
-    return unless pos && pos < cids.size
-
-    step = pnum.fdiv(cids.size).ceil
-    frst = pos*step
-    last = (pos+1)*step-1
+    cid_cnt = cids.length
+    return unless pos && pos < cid_cnt
+    remainder  = pnum % cid_cnt
+    step = secondary_step = pnum / cid_cnt
+    even_step_parts = pnum
+    until even_step_parts % cids.length == 0
+      even_step_parts += 1
+      step = even_step_parts / cid_cnt
+      secondary_step = step - 1
+    end
+    secondary_step_start = remainder*step
+    if pos < remainder
+      frst = pos*step
+      last = (pos+1)*step-1
+    else
+      new_pos = pos-remainder
+      frst = secondary_step_start + new_pos*secondary_step
+      last = secondary_step_start + (new_pos+1)*secondary_step-1
+    end
     last = pnum-1 if last > pnum-1
     return if last < 0 || last < frst
 

--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -56,7 +56,7 @@ class Poseidon::ConsumerGroup
     remainder  = pnum % cid_cnt
     step = secondary_step = pnum / cid_cnt
     even_step_parts = pnum
-    until even_step_parts % cids.length == 0
+    until even_step_parts % cid_cnt == 0
       even_step_parts += 1
       step = even_step_parts / cid_cnt
       secondary_step = step - 1

--- a/lib/poseidon/consumer_group.rb
+++ b/lib/poseidon/consumer_group.rb
@@ -51,28 +51,13 @@ class Poseidon::ConsumerGroup
   def self.pick(pnum, cids, id)
     cids = cids.sort
     pos  = cids.index(id)
-    cid_cnt = cids.length
-    return unless pos && pos < cid_cnt
-    remainder  = pnum % cid_cnt
-    step = secondary_step = pnum / cid_cnt
-    even_step_parts = pnum
-    until even_step_parts % cid_cnt == 0
-      even_step_parts += 1
-      step = even_step_parts / cid_cnt
-      secondary_step = step - 1
-    end
-    secondary_step_start = remainder*step
-    if pos < remainder
-      frst = pos*step
-      last = (pos+1)*step-1
-    else
-      new_pos = pos-remainder
-      frst = secondary_step_start + new_pos*secondary_step
-      last = secondary_step_start + (new_pos+1)*secondary_step-1
-    end
+    return unless pos && pos < cids.size
+    step = pnum / cids.size
+    remainder = pnum % cids.size
+    frst = pos * step + ([pos,remainder].min)
+    last = (pos + 1) * step + ([pos,remainder - 1].min)
     last = pnum-1 if last > pnum-1
     return if last < 0 || last < frst
-
     (frst..last)
   end
 


### PR DESCRIPTION
Allow partition picker to assign partitions to any number of consumers
regardless of whether the partition count is divisible by the consumer
count.
Previously only the first X of Y consumers would be assigned partitions,
where X is the highest number of Y consumers that divide evenly into the partition
count. While this ensured that all consumers assigned partitions had an equal partition
distribution it also meant some consumer got no partitions.
The new algorithm ensures all consumers (up to the number
matching the partition count) will get some partitions, and that the
difference between partition ownership between consumers won't be > 1
Credit to @pablomata for refining the original algorithm implementation and @v-a for uncovering the problem in the first place